### PR TITLE
Update CMake Subdirectory Support (./tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@ build/*
 
 # Output Directory
 bin/*
+bin-test/*
 
 .vscode/settings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,38 +8,23 @@ project(PrettyLazy0 VERSION 0.1)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Include directories
-include_directories(./include)
+# Set defaut build type to Release
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
 
-# Source files
-file(GLOB_RECURSE SOURCES src/*.cpp)
-# Exclude main.cpp from the sources
-list(FILTER SOURCES EXCLUDE REGEX ".*main.cpp$")
-
-# Set output directory: bin/{Release, Debug}/{win,linux,mac}_{x86, x64}
-set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin/${CMAKE_BUILD_TYPE}/${CMAKE_SYSTEM_NAME}_${CMAKE_SYSTEM_PROCESSOR})
-
-# Add executable with the project name
-add_executable(plazy ${SOURCES} "src/main.cpp")
-
-# [To be Tested] Visual Studio Specific Options
 if(MSVC)
     # Set different compile options for Release and Debug modes
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /O2")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Zi")
-
     # MSVC compiler-specific options
     add_compile_options(/permissive- /Zc:forScope)
-
-# g++/clang++ specific options
 else()
     # Set different compile options for Release and Debug modes
     set(CMAKE_CXX_FLAGS_RELEASE "-O3")
     set(CMAKE_CXX_FLAGS_DEBUG "-g")
-    
 endif()
 
-# Copy the executable to the bin/current directory
-# add_custom_command(TARGET plazy POST_BUILD
-#     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:plazy> ${PROJECT_SOURCE_DIR}/bin/current/
-# )
+add_subdirectory(src)
+add_subdirectory(tests)
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Include directories
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
+# Source files
+file(GLOB_RECURSE SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+# Exclude main.cpp from the sources
+list(FILTER SOURCES EXCLUDE REGEX ".*main.cpp$")
+
+
+# Add executable with the project name
+add_executable(plazy ${SOURCES} "./main.cpp")
+
+set_target_properties(
+    plazy PROPERTIES 
+    RUNTIME_OUTPUT_DIRECTORY
+    ${PROJECT_SOURCE_DIR}/bin/${CMAKE_BUILD_TYPE}/${CMAKE_SYSTEM_NAME}_${CMAKE_SYSTEM_PROCESSOR}
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Include directories
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
+# Source files
+file(GLOB_RECURSE SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+# Exclude main.cpp from the sources
+list(FILTER SOURCES EXCLUDE REGEX ".*main.cpp$")
+
+
+# Add executable with the project name
+add_executable(test_main ${SOURCES} "./test_main.cpp")
+
+set_target_properties(
+    test_main PROPERTIES 
+    RUNTIME_OUTPUT_DIRECTORY
+    ${PROJECT_SOURCE_DIR}/bin-test/${CMAKE_BUILD_TYPE}/${CMAKE_SYSTEM_NAME}_${CMAKE_SYSTEM_PROCESSOR}
+)

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main()
+{
+    std::cout << "Test Only.\n";
+}


### PR DESCRIPTION
**The migration of test code should be on the agenda.**

Now when building the project, two binary directory will appear:
- bin
- bin-test

Inside "./bin-test" there should be the test unit binaries building from source files in "./tests".